### PR TITLE
Fix: Add missing useMemo import in Index.tsx

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { Search, Code, Palette, Calculator, FileText, Beaker, Hash, Shield, Settings, ChevronRight } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';


### PR DESCRIPTION
This commit fixes a bug where the application would crash due to a missing `useMemo` import in `src/pages/Index.tsx`. The `useMemo` hook was added to improve the performance of the tool switching functionality, but the import from `react` was missed.